### PR TITLE
Enhance IMU_Orientation constructor initialization

### DIFF
--- a/imu_orientation.h
+++ b/imu_orientation.h
@@ -42,7 +42,16 @@
 
 class IMU_Orientation {
   public:
-    IMU_Orientation(): quaternion(1,0,0,0) {}
+    IMU_Orientation(): quaternion(1,0,0,0)
+    {
+        accel.x = accel.y = accel.z = accel.magnitude = sfFloat(0);
+        gyro.x = gyro.y = gyro.z = gyro.magnitude = sfFloat(0);
+        gyro_bias.x = gyro_bias.y = gyro_bias.z = gyro_bias.magnitude = sfFloat(0);
+        mag.x = mag.y = mag.z = mag.magnitude = sfFloat(0);
+        euler.tilt = sfFloat(0);
+        euler.roll = sfFloat(0);
+        euler.azimuth = sfFloat(0);
+    }
     ~IMU_Orientation() {}
   
     // Data structures


### PR DESCRIPTION
Initialize accelerometer, gyroscope, magnetometer, and Euler angles in the constructor. IMU_Orientation had uninitialized euler and gyro_bias state On the first update() call, that caused NaN propagation in roll/tilt output Initializing those fields fixed the runtime behavior reliably.