### PR TITLE
fix: correct gyro axis assignment in bias calculation (issue #7)

### DIFF
--- a/imu_orientation.cpp
+++ b/imu_orientation.cpp
@@ -87,8 +87,8 @@ void IMU_Orientation::update(sfFloat weight)
 
     // continuously adjust for changing gyro bias
     gyro_bias.x = gyro_bias.x * GYRO_BIAS_COEFF + gyro.x * (sfFloat(1.0) - GYRO_BIAS_COEFF);
-    gyro_bias.y = gyro_bias.y * GYRO_BIAS_COEFF + gyro.x * (sfFloat(1.0) - GYRO_BIAS_COEFF);
-    gyro_bias.z = gyro_bias.z * GYRO_BIAS_COEFF + gyro.x * (sfFloat(1.0) - GYRO_BIAS_COEFF);
+    gyro_bias.y = gyro_bias.y * GYRO_BIAS_COEFF + gyro.y * (sfFloat(1.0) - GYRO_BIAS_COEFF);
+    gyro_bias.z = gyro_bias.z * GYRO_BIAS_COEFF + gyro.z * (sfFloat(1.0) - GYRO_BIAS_COEFF);
 
     gyro.x -= gyro_bias.x;
     gyro.y -= gyro_bias.y;


### PR DESCRIPTION
Fix issue #7: correct gyro axis assignment in gyro_bias calculation.

On lines 89-91 of imu_orientation.cpp, all three axes were reading from `gyro.x` instead of `gyro.x`, `gyro.y`, and `gyro.z` respectively.

